### PR TITLE
Add custom architecture handling to run.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,19 +1,6 @@
 #!/bin/bash
 set -e
-
-arch=$(uname -m)
-case "$arch" in
-  "x86_64" )
-    ;;
-  "armv7l" )
-    base_image_prefix="$arch/"
-    ;;
-  * )
-    echo "Warning: Unsupported architecture: $arch" >&2
-    echo "Build is likely to FAIL" >&2
-    base_image_prefix="$arch/"
-    ;;
-esac
-
-cd "$(dirname "$0")/docker"
-docker build -t "thunderatz/${arch}-ros-base" --build-arg base_image_prefix="$base_image_prefix" .
+cd "$(dirname "$0")"
+source helpers.sh
+image_prefix=$(architecture_prefix)
+docker build -t "thunderatz/${image_prefix}ros-base" --build-arg base_image_prefix=${image_prefix/-/\/} docker/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ${base_image_prefix}ubuntu:xenial
 MAINTAINER Tiago Koji Castro Shibata
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    build-essential dirmngr locales \
+    build-essential dirmngr locales sudo \
     && rm -rf /var/lib/apt/lists/*
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/helpers.sh
+++ b/helpers.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+architecture_prefix() {
+  arch=$(uname -m)
+  # Docker architecture naming differs from the output of uname -m
+  # See https://github.com/docker-library/official-images#architectures-other-than-amd64
+  case "$arch" in
+    "x86_64" )
+    # No prefix for x86_64
+    ;;
+    "armv7l" )
+    echo "arm32v7-"
+    ;;
+    * )
+    echo "Warning: Untested architecture: $arch" >&2
+    echo "Build is likely to FAIL" >&2
+    echo "$arch-"
+    ;;
+  esac
+}

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
-
 cd "$(dirname "$0")"
+source helpers.sh
+
 if which nvidia-docker > /dev/null 2>&1 ; then
     DOCKER=nvidia-docker
 else
@@ -11,7 +12,7 @@ fi
 
 xhost +local:root
 CMD="$DOCKER run --rm --privileged --network host -e DISPLAY -e QT_X11_NO_MITSHM=1 -v /dev/bus/usb -v /tmp/.X11-unix:/tmp/.X11-unix:ro"
-CONTAINER="thunderatz/ros-base"
+CONTAINER="thunderatz/$(architecture_prefix)ros-base"
 if (( $# == 0 )) ; then
     eval "$CMD $CONTAINER"
 else


### PR DESCRIPTION
Dei uma mudada na nomenclatura pra bater com o mais comum no docker (sem prefixo em `x86_64`, prefixos pra `arm*`).