### PR TITLE
CI to build and push images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: ./build-cuda.sh
+      - run: docker build -t "thunderatz/ros-base-cuda" --build-arg base_image=nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04 docker/
       - deploy:
           name: Push Docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,39 +1,70 @@
-version: 2
-jobs:
-  build: &default-build
+defaults:
+  job: &job-defaults
     docker:
       - image: docker:18.05
+version: 2
+jobs:
+  build:
+    <<: *job-defaults
     steps:
       - checkout
       - setup_remote_docker
       - run: ./build.sh
+      - run:
+          name: Save Docker image artifact
+          command: |
+            mkdir -p /tmp/artifacts
+            docker save -o /tmp/artifacts/image.tar thunderatz/ros-base
+      - store_artifacts:
+          path: /tmp/artifacts/image.tar
+      - persist_to_workspace:
+          root: /tmp/artifacts
+          paths:
+            - image.tar
+  push: &push-defaults
+    <<: *job-defaults
+    steps:
+      - setup_remote_docker
+      - attach_workspace:
+          at: /tmp/artifacts
       - deploy:
           name: Push Docker image
           command: |
             if [ ! -z "${DOCKERHUB_USER}" ]; then
+              docker load -i /tmp/artifacts/image.tar
               docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASSWORD}
-              docker push thunderatz/ros-base
+              docker push $(docker images --format '{{.Repository}}' 'thunderatz/*')
             else
               echo Docker credentials not found
             fi
   build-cuda:
-    <<: *default-build
+    <<: *job-defaults
     steps:
       - checkout
       - setup_remote_docker
       - run: docker build -t "thunderatz/ros-base-cuda" --build-arg base_image=nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04 docker/
-      - deploy:
-          name: Push Docker image
+      - run:
+          name: Save Docker image artifact
           command: |
-            if [ ! -z "${DOCKERHUB_USER}" ]; then
-              docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASSWORD}
-              docker push thunderatz/ros-base-cuda
-            else
-              echo Docker credentials not found
-            fi
+            mkdir -p /tmp/artifacts
+            docker save -o /tmp/artifacts/image.tar thunderatz/ros-base-cuda
+      - store_artifacts:
+          path: /tmp/artifacts/image.tar
+      - persist_to_workspace:
+          root: /tmp/artifacts
+          paths:
+            - image.tar
+  push-cuda:
+    <<: *push-defaults
 workflows:
   version: 2
-  build-all:
+  build-and-push:
     jobs:
       - build
+      - push:
+          requires:
+            - build
       - build-cuda
+      - push-cuda:
+          requires:
+            - build-cuda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,30 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: ./build.sh
+      - deploy:
+          name: Push Docker image
+          command: |
+            if [ ! -z "${DOCKERHUB_USER}" ]; then
+              docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASSWORD}
+              docker push thunderatz/ros-base
+            else
+              echo Docker credentials not found
+            fi
   build-cuda:
     <<: *default-build
     steps:
       - checkout
       - setup_remote_docker
       - run: ./build-cuda.sh
+      - deploy:
+          name: Push Docker image
+          command: |
+            if [ ! -z "${DOCKERHUB_USER}" ]; then
+              docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASSWORD}
+              docker push thunderatz/ros-base-cuda
+            else
+              echo Docker credentials not found
+            fi
 workflows:
   version: 2
   build-all:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,18 @@
 version: 2
 jobs:
-  build:
+  build: &default-build
     docker:
       - image: docker:18.05
-    working_directory: ~/ros-base
     steps:
       - checkout
       - setup_remote_docker
-      - run: sh ./build.sh
+      - run: ./build.sh
   build-cuda:
-    docker:
-      - image: docker:18.05
-    working_directory: ~/ros-base
+    <<: *default-build
     steps:
       - checkout
       - setup_remote_docker
-      - run: sh ./build-cuda.sh
+      - run: ./build-cuda.sh
 workflows:
   version: 2
   build-all:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,71 +2,40 @@ defaults:
   job: &job-defaults
     docker:
       - image: docker:18.05
-version: 2
-jobs:
-  build:
-    <<: *job-defaults
     steps:
       - checkout
       - setup_remote_docker
-      - run: ./build.sh
-      - run:
-          name: Save Docker image artifact
-          command: |
-            mkdir -p /tmp/artifacts
-            docker save -o /tmp/artifacts/image.tar thunderatz/ros-base
-      - store_artifacts:
-          path: /tmp/artifacts/image.tar
-          destination: image.tar
-      - persist_to_workspace:
-          root: /tmp/artifacts
-          paths:
-            - image.tar
-  push: &push-defaults
-    <<: *job-defaults
-    steps:
-      - setup_remote_docker
-      - attach_workspace:
-          at: /tmp/artifacts
+      - run: ${BUILD_COMMAND}
       - deploy:
           name: Push Docker image
           command: |
             if [ ! -z "${DOCKERHUB_USER}" ]; then
-              docker load -i /tmp/artifacts/image.tar
               docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASSWORD}
               docker push $(docker images --format '{{.Repository}}' 'thunderatz/*')
             else
               echo Docker credentials not found
             fi
-  build-cuda:
-    <<: *job-defaults
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run: docker build -t "thunderatz/ros-base-cuda" --build-arg base_image=nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04 docker/
       - run:
           name: Save Docker image artifact
           command: |
             mkdir -p /tmp/artifacts
-            docker save -o /tmp/artifacts/image.tar thunderatz/ros-base-cuda
+            docker save -o /tmp/artifacts/image.tar $(docker images --format '{{.Repository}}' 'thunderatz/*')
       - store_artifacts:
           path: /tmp/artifacts/image.tar
           destination: image.tar
-      - persist_to_workspace:
-          root: /tmp/artifacts
-          paths:
-            - image.tar
-  push-cuda:
-    <<: *push-defaults
+version: 2
+jobs:
+  build:
+    <<: *job-defaults
+    environment:
+      BUILD_COMMAND: "./build.sh"
+  build-cuda:
+    <<: *job-defaults
+    environment:
+      BUILD_COMMAND: "docker build -t thunderatz/ros-base-cuda --build-arg base_image=nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04 docker/"
 workflows:
   version: 2
   build-and-push:
     jobs:
       - build
-      - push:
-          requires:
-            - build
       - build-cuda
-      - push-cuda:
-          requires:
-            - build-cuda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,18 +2,19 @@ defaults:
   job: &job-defaults
     docker:
       - image: docker:18.05
+    context: dockerhub-bot
     steps:
       - checkout
       - setup_remote_docker
-      - run: ${BUILD_COMMAND}
+      - run: $BUILD_COMMAND
       - deploy:
           name: Push Docker image
           command: |
-            if [ ! -z "${DOCKERHUB_USER}" ]; then
-              docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASSWORD}
+            if [[ "$CIRCLE_PROJECT_USERNAME" == ThundeRatz && "$CIRCLE_BRANCH" == master ]]; then
+              docker login -u "$DOCKERHUB_USER" -p "$DOCKERHUB_PASSWORD"
               docker push $(docker images --format '{{.Repository}}' 'thunderatz/*')
             else
-              echo Docker credentials not found
+              echo Skipping push to Docker Hub since this is not the master branch in the ThundeRatz organization
             fi
       - run:
           name: Save Docker image artifact

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: docker build -t "thunderatz/ros-base-cuda" --build-arg base_image=nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04 docker/
+      - run: docker build -t "thunderatz/ros-base-cuda" --build-arg base_image=nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04 docker/
       - run:
           name: Save Docker image artifact
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
             docker save -o /tmp/artifacts/image.tar thunderatz/ros-base
       - store_artifacts:
           path: /tmp/artifacts/image.tar
+          destination: image.tar
       - persist_to_workspace:
           root: /tmp/artifacts
           paths:
@@ -50,6 +51,7 @@ jobs:
             docker save -o /tmp/artifacts/image.tar thunderatz/ros-base-cuda
       - store_artifacts:
           path: /tmp/artifacts/image.tar
+          destination: image.tar
       - persist_to_workspace:
           root: /tmp/artifacts
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: docker:18.05
+    working_directory: ~/ros-base
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: sh ./build.sh
+  build-cuda:
+    docker:
+      - image: docker:18.05
+    working_directory: ~/ros-base
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: sh ./build-cuda.sh
+workflows:
+  version: 2
+  build-all:
+    jobs:
+      - build
+      - build-cuda

--- a/build-cuda.sh
+++ b/build-cuda.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-set -e
-cd "$(dirname "$0")"
-docker build -t "thunderatz/ros-base-cuda" --build-arg base_image=nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04 docker/

--- a/build-cuda.sh
+++ b/build-cuda.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 cd "$(dirname "$0")"
 docker build -t "thunderatz/ros-base-cuda" --build-arg base_image=nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04 docker/

--- a/build-cuda.sh
+++ b/build-cuda.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")"
+docker build -t "thunderatz/ros-base-cuda" --build-arg base_image=nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04 docker/

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@ set -e
 cd "$(dirname "$0")"
 source helpers.sh
 image_prefix=$(architecture_prefix)
-docker build -t "thunderatz/${image_prefix}ros-base" --build-arg base_image_prefix=${image_prefix/-/\/} docker/
+docker build -t "thunderatz/${image_prefix}ros-base" --build-arg base_image=${image_prefix/-/\/}ubuntu:xenial docker/

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 cd "$(dirname "$0")"
-source helpers.sh
+source ./helpers.sh
 image_prefix=$(architecture_prefix)
 docker build -t "thunderatz/${image_prefix}ros-base" --build-arg base_image=${image_prefix/-/\/}ubuntu:xenial docker/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-ARG base_image_prefix=
-FROM ${base_image_prefix}ubuntu:xenial
-MAINTAINER Tiago Koji Castro Shibata
+ARG base_image=ubuntu:16.04
+FROM ${base_image}
+LABEL maintainer="Tiago Koji Castro Shibata"
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential dirmngr locales sudo \

--- a/helpers.sh
+++ b/helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 architecture_prefix() {


### PR DESCRIPTION
Está testando que os containers podem ser gerados (ros-base x64 e com CUDA) e dando push das imagens. Um build e push limpos demoram ~3:23 para ros-base e ~4:12 para ros-base-cuda. Coisas a melhorar:

* Separar build e push em jobs diferentes. Vou dar uma olhada no suporte a artefatos do CircleCI e arrumar logo.
* Usar o suporte a cache do CircleCI pra não ter que baixar a imagem base toda a vez, o que aceleraria esses builds. Vou dar uma pesquisada, se for fácil arrumo no futuro próximo.
* Esse repositório (`ros-base`) suporta alvos ARM também. Seria bom gerar os containers pra ARM junto. No futuro, eu gostaria que o repositório do Trekking e outros robôs que usem ROS pegassem ros-base para x64 e ARM e compilassem/rodassem testes em ambos os containers. Não vou mexer nisso agora, mas arrumo no futuro.